### PR TITLE
Setup sponsor-app roles

### DIFF
--- a/iam/roles/Trk12SponsorApp.iam
+++ b/iam/roles/Trk12SponsorApp.iam
@@ -1,0 +1,69 @@
+role "Trk12SponsorAppProduction", path: "/" do
+  assume_role_policy_document do
+    {
+      "Version" => "2012-10-17",
+      "Statement" => [
+        {
+          "Effect" => "Allow",
+          "Principal" => { "Federated" => "arn:aws:iam::529088264854:oidc-provider/oidc.fly.io/tokyorubykaigi12" },
+          "Action" => "sts:AssumeRoleWithWebIdentity",
+          "Condition" => {
+            "StringEquals" => {
+              "oidc.fly.io/tokyorubykaigi12:aud" => "sts.amazonaws.com",
+            },
+            "StringLike" => {
+              "oidc.fly.io/tokyorubykaigi12:sub" => "tokyorubykaigi12:*:*",
+            },
+          }
+        }
+      ]
+    }
+  end
+
+  policy "assume-role" do
+    {
+      "Version" => "2012-10-17",
+      "Statement" => [
+        {
+          "Effect" => "Allow",
+          "Action" => "sts:AssumeRole",
+          "Resource" => "arn:aws:iam::529088264854:role/Trk12SponsorAppImageUploader",
+        },
+      ],
+    }
+  end
+
+  policy "image-management" do
+    {
+      "Version" => "2012-10-17",
+      "Statement" => [
+        {
+          "Effect" => "Allow",
+          "Action" => [
+            "s3:ListBucket",
+          ],
+          "Resource" => [
+            "arn:aws:s3:::trk12-sponsor-app",
+          ],
+          "Condition" => {
+            "StringLike" => {
+              "s3:prefix" => "production",
+            },
+          },
+        },
+        {
+          "Effect" => "Allow",
+          "Action" => [
+            "s3:GetObject",
+            "s3:PutObject",
+          ],
+          "Resource" => [
+            "arn:aws:s3:::trk12-sponsor-app/production/*",
+          ],
+        }
+      ],
+    }
+  end
+end
+
+# vim: set ft=ruby :

--- a/iam/roles/Trk12SponsorAppImageUploader.iam
+++ b/iam/roles/Trk12SponsorAppImageUploader.iam
@@ -1,0 +1,33 @@
+role "Trk12SponsorAppImageUploader", path: "/" do
+  assume_role_policy_document do
+    {
+      "Version" => "2012-10-17",
+      "Statement" => [
+        {
+          "Effect" => "Allow",
+          "Principal" => { "AWS" => "arn:aws:iam::529088264854:root" },
+          "Action" => "sts:AssumeRole"
+        }
+      ]
+    }
+  end
+
+  policy "image-upload-from-browser" do
+    {
+      "Version" => "2012-10-17",
+      "Statement" => [
+        {
+          "Effect" => "Allow",
+          "Action" => [
+            "s3:PutObject",
+          ],
+          "Resource" => [
+            "arn:aws:s3:::trk12-sponsor-app/production/*",
+          ],
+        }
+      ],
+    }
+  end
+end
+
+# vim: set ft=ruby :

--- a/terraform/flyio-oidc/.terraform.lock.hcl
+++ b/terraform/flyio-oidc/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.66.0"
+  hashes = [
+    "h1:RHs4rOiKrKJqr8UhVW7yqfoMVwaofQ+9ChP41rAzc1A=",
+    "zh:071c908eb18627f4becdaf0a9fe95d7a61f69be365080aba2ef5e24f6314392b",
+    "zh:3dea2a474c6ad4be5b508de4e90064ec485e3fbcebb264cb6c4dec660e3ea8b5",
+    "zh:56c0b81e3bbf4e9ccb2efb984f8758e2bc563ce179ff3aecc1145df268b046d1",
+    "zh:5f34b75a9ef69cad8c79115ecc0697427d7f673143b81a28c3cf8d5decfd7f93",
+    "zh:65632bc2c408775ee44cb32a72e7c48376001a9a7b3adbc2c9b4d088a7d58650",
+    "zh:6d0550459941dfb39582fadd20bfad8816255a827bfaafb932d51d66030fcdd5",
+    "zh:7f1811ef179e507fdcc9776eb8dc3d650339f8b84dd084642cf7314c5ca26745",
+    "zh:8a793d816d7ef57e71758fe95bf830cfca70d121df70778b65cc11065ad004fd",
+    "zh:8c7cda08adba01b5ae8cc4e5fbf16761451f0fab01327e5f44fc47b7248ba653",
+    "zh:96d855f1771342771855c0fb2d47ff6a731e8f2fa5d242b18037c751fd63e6c3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b2a62669b72c2471820410b58d764102b11c24e326831ddcfae85c7d20795acf",
+    "zh:b4a6b251ac24c8f5522581f8d55238d249d0008d36f64475beefc3791f229e1d",
+    "zh:ca519fa7ee1cac30439c7e2d311a0ecea6a5dae2d175fe8440f30133688b6272",
+    "zh:fbcd54e7d65806b0038fc8a0fbdc717e1284298ff66e22aac39dcc5a22cc99e5",
+  ]
+}

--- a/terraform/flyio-oidc/backend.tf
+++ b/terraform/flyio-oidc/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "trk12-infra"
+    key    = "terraform/flyio-oidc.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/terraform/flyio-oidc/iam.tf
+++ b/terraform/flyio-oidc/iam.tf
@@ -1,0 +1,5 @@
+resource "aws_iam_openid_connect_provider" "flyio-tokyorubykaigi12" {
+  url = "https://oidc.fly.io/tokyorubykaigi12"
+  client_id_list = ["sts.amazonaws.com"]
+  thumbprint_list = ["5f28d9c589ee4bf31a11b78c72b8d13f079ddc45"]
+}

--- a/terraform/flyio-oidc/provider.tf
+++ b/terraform/flyio-oidc/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/terraform/sponsor-app/.terraform.lock.hcl
+++ b/terraform/sponsor-app/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.66.0"
+  hashes = [
+    "h1:RHs4rOiKrKJqr8UhVW7yqfoMVwaofQ+9ChP41rAzc1A=",
+    "zh:071c908eb18627f4becdaf0a9fe95d7a61f69be365080aba2ef5e24f6314392b",
+    "zh:3dea2a474c6ad4be5b508de4e90064ec485e3fbcebb264cb6c4dec660e3ea8b5",
+    "zh:56c0b81e3bbf4e9ccb2efb984f8758e2bc563ce179ff3aecc1145df268b046d1",
+    "zh:5f34b75a9ef69cad8c79115ecc0697427d7f673143b81a28c3cf8d5decfd7f93",
+    "zh:65632bc2c408775ee44cb32a72e7c48376001a9a7b3adbc2c9b4d088a7d58650",
+    "zh:6d0550459941dfb39582fadd20bfad8816255a827bfaafb932d51d66030fcdd5",
+    "zh:7f1811ef179e507fdcc9776eb8dc3d650339f8b84dd084642cf7314c5ca26745",
+    "zh:8a793d816d7ef57e71758fe95bf830cfca70d121df70778b65cc11065ad004fd",
+    "zh:8c7cda08adba01b5ae8cc4e5fbf16761451f0fab01327e5f44fc47b7248ba653",
+    "zh:96d855f1771342771855c0fb2d47ff6a731e8f2fa5d242b18037c751fd63e6c3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b2a62669b72c2471820410b58d764102b11c24e326831ddcfae85c7d20795acf",
+    "zh:b4a6b251ac24c8f5522581f8d55238d249d0008d36f64475beefc3791f229e1d",
+    "zh:ca519fa7ee1cac30439c7e2d311a0ecea6a5dae2d175fe8440f30133688b6272",
+    "zh:fbcd54e7d65806b0038fc8a0fbdc717e1284298ff66e22aac39dcc5a22cc99e5",
+  ]
+}

--- a/terraform/sponsor-app/backend.tf
+++ b/terraform/sponsor-app/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "trk12-infra"
+    key    = "terraform/sponsor-app.tfstate"
+    region = "ap-northeast-1"
+  }
+}

--- a/terraform/sponsor-app/provider.tf
+++ b/terraform/sponsor-app/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/terraform/sponsor-app/s3.tf
+++ b/terraform/sponsor-app/s3.tf
@@ -1,0 +1,14 @@
+resource "aws_s3_bucket" "trk12-sponsor-app" {
+  bucket = "trk12-sponsor-app"
+}
+
+resource "aws_s3_bucket_cors_configuration" "trk12-sponsor-app" {
+  bucket = aws_s3_bucket.trk12-sponsor-app.id
+
+  cors_rule {
+    allowed_origins = ["*"]
+    allowed_methods = ["HEAD", "GET", "PUT", "POST"]
+    allowed_headers = ["*"]
+    expose_headers  = ["ETag"]
+  }
+}


### PR DESCRIPTION
- Fly.io から OIDC による AssumeRole を許可
  - https://fly.io/docs/security/openid-connect/#reading-from-an-s3-bucket-on-a-fly-machine
- sponsor-app が直接使うロール `Trk12SponsorApp` の作成
- 画像アップローダーが使うロール `Trk12SponsorAppImageUploader` の作成
- 画像がアップロードされる S3 バケット s3://trk12-sponsor-app の作成